### PR TITLE
Make portfolio pages ultra minimal

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -9,31 +9,10 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
-    <a href="index.html">Home</a>
-    <a href="about.html">About</a>
-    <a href="projects.html">Projects</a>
   </nav>
-
-  <header class="hero">
-    <h1>About Me</h1>
-  </header>
-
   <main>
-    <div class="split">
-      <div>
-        <p>Hi, I'm Sam Carter, a lab technician and robotics instructor from
-        Carlsbad, California. At GKN Additive I managed SLA, PolyJet, and FDM
-        printers for custom manufacturing.</p>
-        <p>I've coordinated robotics programs with the Carlsbad Educational
-        Foundation and mentored dozens of student teams. Outside the lab I enjoy
-        hiking and supporting community STEM outreach.</p>
-      </div>
-      <div class="avatar"></div>
-    </div>
+    <p>Sam Carter is a lab technician and robotics instructor from Carlsbad, California.</p>
   </main>
-
-  <footer>
-    © 2025 Sam Carter
-  </footer>
+  <footer>© 2025 Sam Carter</footer>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,38 +3,21 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Sam Carter • Lab Tech & Robotics Instructor</title>
+  <title>Sam Carter</title>
   <link rel="stylesheet" href="style.css">
-  <script defer src="typewriter.js"></script>
 </head>
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
-    <a href="index.html">Home</a>
     <a href="about.html">About</a>
     <a href="projects.html">Projects</a>
   </nav>
-
-  <header class="hero">
-    <div class="avatar"></div>
+  <header>
     <h1>Sam Carter</h1>
-    <p class="typewriter"><span id="typewriter"></span><span class="cursor"></span></p>
-    <div class="buttons">
-      <a class="btn" href="resume.pdf">📄 Resume</a>
-      <a class="btn" href="mailto:sam@example.com">📬 Contact</a>
-      <a class="btn" href="projects.html">⚡ Projects</a>
-    </div>
   </header>
-
   <main>
-    <section>
-      <p>Welcome to my portfolio. Learn more <a href="about.html">about me</a> or
-      check out some <a href="projects.html">projects</a>.</p>
-    </section>
+    <p>Lab tech and robotics instructor.</p>
   </main>
-
-  <footer>
-    © 2025 Sam Carter
-  </footer>
+  <footer>© 2025 Sam Carter</footer>
 </body>
 </html>

--- a/docs/projects.html
+++ b/docs/projects.html
@@ -9,32 +9,13 @@
 <body>
   <nav>
     <a class="logo" href="index.html">Sam Carter</a>
-    <a href="index.html">Home</a>
-    <a href="about.html">About</a>
-    <a href="projects.html">Projects</a>
   </nav>
-
-  <header class="hero">
-    <h1>Projects</h1>
-  </header>
-
   <main>
-    <div class="projects">
-      <div class="card">
-        <h2>3D Printing Operations</h2>
-        <p>Oversaw SLA, PolyJet, and FDM printers at GKN Additive to produce custom
-        parts and prototypes.</p>
-      </div>
-      <div class="card">
-        <h2>Robotics Mentorship</h2>
-        <p>Developed curriculum and mentored more than 50 middle school teams
-        through the Carlsbad Educational Foundation.</p>
-      </div>
-    </div>
+    <ul>
+      <li>3D printing operations at GKN Additive.</li>
+      <li>Robotics mentorship with CEF.</li>
+    </ul>
   </main>
-
-  <footer>
-    © 2025 Sam Carter
-  </footer>
+  <footer>© 2025 Sam Carter</footer>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,190 +1,30 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500&family=Space+Grotesk:wght@400;700;900&display=swap');
-
-* {
-  box-sizing: border-box;
-}
-
-:root {
-  --primary: #0f0f0f;
-  --navy: #1f2937;
-  --accent: #38bdf8;
-}
-
 body {
-  margin: 0;
-  font-family: 'IBM Plex Sans', sans-serif;
-  line-height: 1.6;
-  background: radial-gradient(circle at top left, var(--navy), var(--primary));
-  color: #eee;
-  font-size: 1.2rem;
+  margin: 2rem;
+  font-family: sans-serif;
+  background: #fff;
+  color: #000;
 }
-
 nav {
-  background: var(--primary);
-  color: #fff;
-  padding: 1rem;
-  display: flex;
-  gap: 1rem;
-}
-
-nav a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: 500;
-  position: relative;
-}
-
-nav a::after {
-  content: '';
-  position: absolute;
-  bottom: -2px;
-  left: 0;
-  width: 0;
-  height: 2px;
-  background: var(--accent);
-  transition: width 0.3s ease;
-}
-
-nav a:hover::after {
-  width: 100%;
-}
-
-nav a.logo {
-  font-weight: 900;
-  margin-right: auto;
-}
-
-header {
-  text-align: center;
-  padding: 4rem 1rem;
-}
-
-p {
-  font-size: 1.1em;
-}
-
-h1 {
-  font-family: 'Space Grotesk', sans-serif;
-  font-size: 3rem;
-  margin: 0 0 0.5rem 0;
-  font-weight: 900;
-}
-
-h2 {
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 700;
-}
-
-.avatar {
-  width: 120px;
-  height: 120px;
-  margin: 0 auto 1.5rem auto;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), #9333ea);
-  transition: transform 0.6s ease;
-}
-
-.avatar:hover {
-  transform: rotate(20deg) scale(1.05);
-}
-
-.split {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-  align-items: center;
-}
-
-.split .avatar {
-  flex: 0 0 150px;
-}
-
-.badges {
-  display: flex;
-  overflow-x: auto;
-  gap: 0.5rem;
-  padding: 1rem 0;
-}
-
-.badge {
-  white-space: nowrap;
-  padding: 0.3rem 0.8rem;
-  border-radius: 9999px;
-  border: 1px solid var(--accent);
-  color: var(--accent);
-  font-size: 0.9rem;
-}
-
-.projects {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.5rem;
-}
-
-.card {
-  background: rgba(255,255,255,0.05);
-  border-radius: 0.5rem;
-  padding: 1rem;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 10px 15px rgba(0,0,0,0.3);
-}
-
-main {
-  max-width: 900px;
-  margin: auto;
-  padding: 1rem;
-}
-
-section {
   margin-bottom: 2rem;
 }
-
-.hero .typewriter {
-  color: var(--accent);
-  min-height: 2.2rem;
-  font-weight: 300;
-}
-
-.cursor {
-  display: inline-block;
-  width: 2px;
-  background: var(--accent);
-  margin-left: 2px;
-  animation: blink 1s infinite;
-}
-
-@keyframes blink {
-  0%, 50% { opacity: 1; }
-  50.01%, 100% { opacity: 0; }
-}
-
-.buttons {
-  margin-top: 1.5rem;
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-}
-
-.btn {
-  padding: 0.6rem 1rem;
-  border-radius: 9999px;
-  border: 1px solid var(--accent);
-  color: var(--accent);
+nav a {
+  margin-right: 1rem;
+  color: #000;
   text-decoration: none;
-  transition: background 0.3s ease;
 }
-
-.btn:hover {
-  background: rgba(56, 189, 248, 0.15);
+nav a.logo {
+  font-weight: bold;
 }
-
-footer {
+header {
   text-align: center;
-  padding: 1rem;
-  background: var(--navy);
-  color: #bbb;
+  margin-bottom: 1rem;
+}
+main {
+  max-width: 600px;
+  margin: auto;
+}
+footer {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 0.9rem;
 }


### PR DESCRIPTION
## Summary
- drastically simplify index/about/projects pages
- remove fancy features, leaving plain text links
- trim CSS to a tiny minimalist style

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68796d1c1d8883339e409c1e590061b0